### PR TITLE
Move linkedin.com from direct to proxy

### DIFF
--- a/factory/resultant/top500_direct.list
+++ b/factory/resultant/top500_direct.list
@@ -127,7 +127,6 @@ lavanguardia.com
 lefigaro.fr
 lego.com
 lg.com
-linkedin.com
 linktr.ee
 list-manage.com
 live.com

--- a/factory/resultant/top500_proxy.list
+++ b/factory/resultant/top500_proxy.list
@@ -114,6 +114,7 @@ kakao.com
 lemonde.fr
 lexpress.fr
 line.me
+linkedin.com
 loc.gov
 m.me
 m.wikipedia.org


### PR DESCRIPTION
LinkedIn China from 2021 onwards only offers the Job hunting functionalities and removed all the social networking features.