### PR TITLE
Move spotify.com from direct to proxy

### DIFF
--- a/factory/resultant/top500_direct.list
+++ b/factory/resultant/top500_direct.list
@@ -211,7 +211,6 @@ skype.com
 so-net.ne.jp
 softonic.com
 sports.yahoo.com
-spotify.com
 springer.com
 sputniknews.com
 standard.co.uk

--- a/factory/resultant/top500_proxy.list
+++ b/factory/resultant/top500_proxy.list
@@ -170,6 +170,7 @@ slideshare.net
 smh.com.au
 soundcloud.com
 spiegel.de
+spotify.com
 ssl-images-amazon.com
 stackoverflow.com
 stanford.edu


### PR DESCRIPTION
Spotify is not blocked by GFW, but using it with a Chinese IP for more than two weeks on a non-premium account, will have the account disabled.