### PR TITLE
Move gstatic.com from direct to proxy

### DIFF
--- a/factory/resultant/top500_direct.list
+++ b/factory/resultant/top500_direct.list
@@ -98,7 +98,6 @@ globo.com
 gnu.org
 godaddy.com
 gooyaabitemplates.com
-gstatic.com
 hatena.ne.jp
 hbr.org
 hollywoodreporter.com

--- a/factory/resultant/top500_proxy.list
+++ b/factory/resultant/top500_proxy.list
@@ -94,6 +94,7 @@ googleblog.com
 googleusercontent.com
 gravatar.com
 groups.google.com
+gstatic.com
 guardian.co.uk
 harvard.edu
 huffingtonpost.com


### PR DESCRIPTION
fonts.gstatic.com and www.gstatic.com used for Google Spreadsheet web are both being blocked by GFW.