### PR TITLE
Add four ad domains

### DIFF
--- a/factory/manual_reject.txt
+++ b/factory/manual_reject.txt
@@ -62,6 +62,11 @@ anquan.org
 appads.com
 applifier.com
 applovin.com
+applvn.com
+ironsrc.com
+app-measurement.com
+pangle.com
+unityads.com
 chartboost.com
 clicktracks.com
 clickzs.com


### PR DESCRIPTION
|domain|description|
|-|-|
|applvn.com|applovin.com的第二域名|
|ironsrc.com|ironSource | https://www.is.com/，ad company|
|app-measurement.com| |
|pangle.com|移动应用广告投放平台 - Pangle|
|unityads.com|unity 广告|