### PR TITLE
feat: safari 翻译跳过代理

### DIFF
--- a/factory/template/sr_head.txt
+++ b/factory/template/sr_head.txt
@@ -6,7 +6,7 @@
 # 默认关闭 ipv6 支持，如果需要请手动开启
 ipv6 = false
 bypass-system = true
-skip-proxy = 192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12, localhost, *.local, e.crashlytics.com, captive.apple.com
+skip-proxy = 192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12, localhost, *.local, e.crashlytics.com, captive.apple.com, sequoia.apple.com, seed-sequoia.siri.apple.com
 bypass-tun = 10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,192.0.0.0/24,192.0.2.0/24,192.88.99.0/24,192.168.0.0/16,198.18.0.0/15,198.51.100.0/24,203.0.113.0/24,224.0.0.0/4,255.255.255.255/32
 dns-server = https://1.12.12.12/dns-query, https://223.5.5.5/dns-query
 [Rule]


### PR DESCRIPTION
macos 13 及往后版本，safari 浏览器自带的翻译不允许存在代理行为（无论什么模式），会无法使用，对常挂梯子的用户不是很友好。
解决方案要么关闭代理（很麻烦），要么绕过代理。
影响范围：只是两个翻译的api绕过而已。