### PR TITLE
devv.ai 设置为走代理

### DIFF
--- a/factory/manual_proxy.txt
+++ b/factory/manual_proxy.txt
@@ -445,3 +445,6 @@ hoyolab.com
 
 # 防止 bing 地区检测
 location.microsoft.com
+
+# devv
+devv.ai


### PR DESCRIPTION
「devv.ai 因为被恶意举报，在大陆地区的访问已经被 DNS 污染了，需要采用科学上网方式。」

https://m.okjike.com/originalPosts/65adea05de5f287348f352ec