### PR TITLE
fix(whitelist): correct the priority of manual rules

### DIFF
--- a/factory/template/sr_top500_whitelist.txt
+++ b/factory/template/sr_top500_whitelist.txt
@@ -6,19 +6,18 @@
 # 不包含广告过滤
 #
 
+{{manual_direct}}
+{{manual_proxy}}
+
 {{top500_direct}}
 
 DOMAIN-SUFFIX,cn,DIRECT
 GEOIP,CN,DIRECT
 
-{{manual_direct}}
-
 IP-CIDR,192.168.0.0/16,DIRECT
 IP-CIDR,10.0.0.0/8,DIRECT
 IP-CIDR,172.16.0.0/12,DIRECT
 IP-CIDR,127.0.0.0/8,DIRECT
-
-{{manual_proxy}}
 
 RULE-SET,https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Shadowrocket/AppleNews/AppleNews.list,PROXY
 

--- a/factory/template/sr_top500_whitelist_ad.txt
+++ b/factory/template/sr_top500_whitelist_ad.txt
@@ -10,19 +10,18 @@
 {{ad}}
 {{manual_reject}}
 
+{{manual_direct}}
+{{manual_proxy}}
+
 {{top500_direct}}
 
 DOMAIN-SUFFIX,cn,DIRECT
 GEOIP,CN,DIRECT
 
-{{manual_direct}}
-
 IP-CIDR,192.168.0.0/16,DIRECT
 IP-CIDR,10.0.0.0/8,DIRECT
 IP-CIDR,172.16.0.0/12,DIRECT
 IP-CIDR,127.0.0.0/8,DIRECT
-
-{{manual_proxy}}
 
 RULE-SET,https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Shadowrocket/AppleNews/AppleNews.list,PROXY
 


### PR DESCRIPTION
manual rules should have a higher priority than top500 rules.

fix #268