### PR TITLE
click.discord.com 设置为走代理

### DIFF
--- a/factory/manual_proxy.txt
+++ b/factory/manual_proxy.txt
@@ -466,3 +466,6 @@ mc-heads.net
 # 越狱下载源加速
 apt.thebigboss.org
 repo.chariz.com
+
+# Discord 邮件里的点击链接，包括新设备登录确认、重置密码等
+click.discord.com


### PR DESCRIPTION
Discord 邮件里的点击链接，包括新设备登录确认、重置密码等