### PR TITLE
add IHG Internet Acess website to direct list

### DIFF
--- a/factory/manual_direct.txt
+++ b/factory/manual_direct.txt
@@ -116,3 +116,6 @@ cn.bing.com
 
 # 凉屋游戏
 chillyroom.com
+
+# IHG Internet Access
+portal.linkbroad.com


### PR DESCRIPTION
IHG 酒店连接 Wi-Fi 的网址需要直连